### PR TITLE
Allow bot to use OMBI_BOT_TOKEN and OMBI_BOT_NAME as env variables

### DIFF
--- a/ombi-bot/src/main/scala/org/stacktrace/yo/ombi/OmbiBot.scala
+++ b/ombi-bot/src/main/scala/org/stacktrace/yo/ombi/OmbiBot.scala
@@ -387,8 +387,8 @@ object ConfigLoader {
 
     val ombiHost = params.getOrElse("OMBI_HOST", throw new IllegalArgumentException("ENV file is missing Missing OMBI_HOST"))
     val ombiKey = params.getOrElse("OMBI_KEY", throw new IllegalArgumentException("ENV file is missing Missing OMBI_KEY"))
-    val botToken = params.getOrElse("BOT_TOKEN", throw new IllegalArgumentException("ENV file is missing Missing BOT_TOKEN"))
-    val botName = params.getOrElse("BOT_NAME", throw new IllegalArgumentException("ENV file is missing Missing BOT_NAME"))
+    val botToken = params.getOrElse("BOT_TOKEN", params.getOrElse("OMBI_BOT_TOKEN" , throw new IllegalArgumentException("ENV file is missing Missing BOT_TOKEN or OMBI_BOT_TOKEN")))
+    val botName = params.getOrElse("BOT_NAME", params.getOrElse("OMBI_BOT_NAME" , throw new IllegalArgumentException("ENV file is missing Missing BOT_NAME or OMBI_BOT_NAME")))
     val user = params.get("OMBI_USER_NAME")
 
     BotConfig(


### PR DESCRIPTION
I changed the environment variables in 2.0. This allows for the same env variables to be used from the 1.x version.